### PR TITLE
Fix all if statements by making them constraints

### DIFF
--- a/snark_circuit/if-gadgets.circom
+++ b/snark_circuit/if-gadgets.circom
@@ -1,0 +1,62 @@
+include "../circomlib/circuits/comparators.circom"
+include "../circomlib/circuits/switcher.circom"
+include "../circomlib/circuits/gates.circom"
+
+template IfBothHighForceEqual() {
+    // check if these are both high, if so constrain equality on a and b
+    signal private input to_x;
+    signal private input to_y;
+
+    signal private input a;
+    signal private input b;
+
+    var ZERO = 0;
+    var ONE = 1;
+
+    component zc[3];
+    component or;
+    component equalIf;
+
+    zc[0] = IsZero();
+    zc[1] = IsZero();
+    zc[2] = IsZero();
+    or = OR();
+
+    zc[0].in <== to_x;
+    zc[1].in <== to_y;
+
+    or.a <== zc[0].out;
+    or.b <== zc[1].out;
+
+    zc[2].in <== or.out;
+
+    equalIf = ForceEqualIfEnabled();
+    equalIf.in[0] <== a;
+    equalIf.in[1] <== b;
+    equalIf.enabled <== zc[2].out;
+}
+
+
+template IfBothLowForceEqual() {
+    // check if these are both low, if so constrain equality on a and b
+    signal private input to_x;
+    signal private input to_y;
+
+    signal private input a;
+    signal private input b;
+
+    component zc[2];
+    component ifBothHigh;
+
+    zc[0] = IsZero();
+    zc[1] = IsZero();
+
+    zc[0].in <== to_x;
+    zc[1].in <== to_y;
+
+    ifBothHigh = IfBothHighForceEqual();
+    ifBothHigh.to_x <== zc[0].out;
+    ifBothHigh.to_y <== zc[1].out;
+    ifBothHigh.a <== a;
+    ifBothHigh.b <== b;
+}

--- a/snark_circuit/if-gadgets.circom
+++ b/snark_circuit/if-gadgets.circom
@@ -2,61 +2,78 @@ include "../circomlib/circuits/comparators.circom"
 include "../circomlib/circuits/switcher.circom"
 include "../circomlib/circuits/gates.circom"
 
-template IfBothHighForceEqual() {
-    // check if these are both high, if so constrain equality on a and b
-    signal private input to_x;
-    signal private input to_y;
-
-    signal private input a;
-    signal private input b;
-
-    var ZERO = 0;
-    var ONE = 1;
-
-    component zc[3];
-    component or;
-    component equalIf;
-
-    zc[0] = IsZero();
-    zc[1] = IsZero();
-    zc[2] = IsZero();
-    or = OR();
-
-    zc[0].in <== to_x;
-    zc[1].in <== to_y;
-
-    or.a <== zc[0].out;
-    or.b <== zc[1].out;
-
-    zc[2].in <== or.out;
-
-    equalIf = ForceEqualIfEnabled();
-    equalIf.in[0] <== a;
-    equalIf.in[1] <== b;
-    equalIf.enabled <== zc[2].out;
+// Maps ints to (0, 1). Maps 0 to 0 and all other ints to 1.
+template ToBool() {
+    signal input x;
+    signal output out;
+    component iszA = IsZero();
+    component iszB = IsZero();
+    iszA.in <== x;
+    iszB.in <== iszA.out;
+    out <== iszB.out;
 }
 
+// Outputs 1 if all k inputs are high.
+template AllHigh(k) {
+    signal input in[k];
+    signal output out;
 
-template IfBothLowForceEqual() {
-    // check if these are both low, if so constrain equality on a and b
-    signal private input to_x;
-    signal private input to_y;
+    component makeBool[k];
+    for (var i = 0; i < k; i++) {
+    	makeBool[i] = ToBool();
+    	makeBool[i].x <== in[i];
+    }
 
-    signal private input a;
-    signal private input b;
+    component mand = MultiAND(k)
+    for (var i = 0; i < k; i++) {
+    	mand.in[i] <== makeBool[i].out;
+    }
+    out <== mand.out;
+}
 
-    component zc[2];
-    component ifBothHigh;
+// Outputs 1 if all k inputs are low.
+template AllLow(k) {
+    signal input in[k];
+    signal output out;
 
-    zc[0] = IsZero();
-    zc[1] = IsZero();
+    component isz[k];
+    component allHigh = AllHigh(k);
+    for (var i = 0; i < k; i++) {
+    	isz[i] = IsZero();
+        isz[i].in <== in[i];
+	allHigh.in[i] <== isz[i].out;
+    }
+    out <== allHigh.out;
+}
 
-    zc[0].in <== to_x;
-    zc[1].in <== to_y;
+template IfBothHighForceEqual() {
+    // check if these are both high, if so constrain equality on a and b
+    signal input check1;
+    signal input check2;
 
-    ifBothHigh = IfBothHighForceEqual();
-    ifBothHigh.to_x <== zc[0].out;
-    ifBothHigh.to_y <== zc[1].out;
-    ifBothHigh.a <== a;
-    ifBothHigh.b <== b;
+    signal input a;
+    signal input b;
+
+    component allHigh = AllHigh(2);
+    allHigh.in[0] <== check1;
+    allHigh.in[1] <== check2;
+
+    component equalIf = ForceEqualIfEnabled();
+    equalIf.in[0] <== a;
+    equalIf.in[1] <== b;
+    equalIf.enabled <== allHigh.out;
+}
+
+template IfAThenBElseC() {
+    signal input aCond;
+    signal input bBranch;
+    signal input cBranch;
+    signal output out;
+
+    component switcher = Switcher();
+    switcher.L <== bBranch;
+    switcher.R <== cBranch;
+    switcher.sel <== aCond;
+
+    out <== switcher.outR;
 }


### PR DESCRIPTION
Addressing the incorrect compiler assumptions and forcing constraints wrapped in if statements.  Please advise on more general if-statement gadgets if you know of them.  We couldn't reuse these gadgets to replace the other 4 if statements because they include a signal connection in the if loop (not just a constraint).

joint work with @yaliu14

cc @rot13 @therealyingtong 